### PR TITLE
Fix cspmcheckeri dependencies.

### DIFF
--- a/cspmchecker/cspmchecker.cabal
+++ b/cspmchecker/cspmchecker.cabal
@@ -48,6 +48,6 @@ Executable cspmcheckeri
         filepath >= 1.2, 
         mtl >= 2.0,
         directory >= 1.0,
-        haskeline >= 0.6
+        haskeline >= 0.7
   
     Hs-Source-Dirs: src/InteractiveChecker


### PR DESCRIPTION
Just trying out your csp checker & discovered that it won't build on Debian testing with the system libraries: had to install the latest haskeline by hand.
